### PR TITLE
done

### DIFF
--- a/DbContext/encrypted_logger.py
+++ b/DbContext/encrypted_logger.py
@@ -24,10 +24,10 @@ class EncryptedLogger:
         with open(self.logfile_path, "r") as f:
             return sum(1 for _ in f) + 1
 
-    def log_entry(self, username, activity, additional_info="", suspicious="No"):
+    def log_entry(self, username, activity, additional_info="", suspicious="No", status="new"):
         now = datetime.now()
         no = self._get_next_no()
-        entry = f"{no}|{now.strftime('%d-%m-%Y')}|{now.strftime('%H:%M:%S')}|{username}|{activity}|{additional_info}|{suspicious}"
+        entry = f"{no}|{now.strftime('%d-%m-%Y')}|{now.strftime('%H:%M:%S')}|{username}|{activity}|{additional_info}|{suspicious}|{status}"
         encrypted = fernet.encrypt(entry.encode()).decode()
         with open(self.logfile_path, "a") as f:
             f.write(encrypted + "\n")
@@ -49,7 +49,7 @@ class EncryptedLogger:
                 print("|".join(row))
 
     def _print_table(self, rows):
-        headers = ["No.", "Date", "Time", "Username", "Description of activity", "Additional Information", "Suspicious"]
+        headers = ["No.", "Date", "Time", "Username", "Description of activity", "Additional Information", "Suspicious", "Status"]
         col_widths = [max(len(str(row[i])) for row in ([headers] + rows)) for i in range(len(headers))]
         def fmt_row(row):
             return " | ".join(str(row[i]).ljust(col_widths[i]) for i in range(len(headers)))

--- a/SuperAdmin/super_admin_menu.py
+++ b/SuperAdmin/super_admin_menu.py
@@ -1,9 +1,10 @@
-from DbContext.encrypted_logger import EncryptedLogger
+from DbContext.encrypted_logger import EncryptedLogger, fernet
 from SuperAdmin.super_admin import SuperAdmin
 from systemAdmin.system_admin import systemAdmin
 from systemAdmin.system_admin_menu import system_admin_service_engineer_menu
 from traveller.Traveller_menu import traveller_menu
 from scooter.Scooter import main
+import os
 
 
 def super_admin_menu(username):
@@ -31,7 +32,47 @@ def super_admin_menu(username):
             main("superadmin", username)
         elif choice == "5":
             logger = EncryptedLogger()
-            logger.read_logs(table_format=True)
+            # Read and separate logs by status
+            if not hasattr(logger, 'logfile_path') or not logger.logfile_path:
+                print("No log file found.")
+            elif not os.path.exists(logger.logfile_path):
+                print("No log file found.")
+            else:
+                new_logs = []
+                old_logs = []
+                all_rows = []
+                with open(logger.logfile_path, "r") as f:
+                    for line in f:
+                        decrypted = fernet.decrypt(line.strip().encode()).decode()
+                        parts = decrypted.split("|")
+                        if len(parts) == 8:
+                            if parts[-1] == "new":
+                                new_logs.append(parts)
+                            else:
+                                old_logs.append(parts)
+                        all_rows.append(parts)
+                # Print old logs table
+                if old_logs:
+                    print("\n--- OLD LOGS ---")
+                    logger._print_table(old_logs)
+                else:
+                    print("\nNo old logs.")
+                # Print new logs table
+                if new_logs:
+                    print("\n--- NEW LOGS ---")
+                    logger._print_table(new_logs)
+                else:
+                    print("\nNo new logs.")
+                # Mark all new logs as old
+                if new_logs:
+                    updated_lines = []
+                    for row in all_rows:
+                        if len(row) == 8 and row[-1] == "new":
+                            row[-1] = "old"
+                        updated_lines.append(fernet.encrypt("|".join(row).encode()).decode())
+                    with open(logger.logfile_path, "w") as f:
+                        for line in updated_lines:
+                            f.write(line + "\n")
         elif choice == "6":
             sysAd= systemAdmin()
             print("\n-- View All User Accounts --")


### PR DESCRIPTION
This pull request introduces enhancements to the `EncryptedLogger` functionality, focusing on log management and role-based alerts. Key changes include the addition of a `status` field for logs, separation of logs by status, and alerts for new suspicious logs for specific roles. These updates improve log visibility and streamline log review workflows.

### Log Management Enhancements:
* **Added `status` field to logs**: The `log_entry` method in `DbContext/encrypted_logger.py` now includes a `status` parameter, defaulting to `"new"`. This change ensures logs can be categorized as "new" or "old" for better tracking. (`[DbContext/encrypted_logger.pyL27-R30](diffhunk://#diff-376d839a22eaf55d5b4622f0190c44c0cfef97a19a064b6ed28fc273a8e09b84L27-R30)`)
* **Updated log headers**: The `_print_table` method now includes the `status` column in the table headers for displaying logs. (`[DbContext/encrypted_logger.pyL52-R52](diffhunk://#diff-376d839a22eaf55d5b4622f0190c44c0cfef97a19a064b6ed28fc273a8e09b84L52-R52)`)
* **Separated logs by status**: Both `super_admin_menu` and `system_admin_menu` functions now read logs, separate them into "new" and "old" categories, display them separately, and mark "new" logs as "old" after review. (`[[1]](diffhunk://#diff-dc1cbd473707e315db118779e4b6227d6b61d5c8837eeb36fd16c45716acc6e5L34-R75)`, `[[2]](diffhunk://#diff-ecda9b2291f096215813c21f006c5ac61b3c622af170797ba5ddc5134c5d3d27L38-R79)`)

### Role-Based Alerts:
* **Suspicious log alerts for admins**: The `show_main_menu` function in `um_members.py` alerts `superadmin` and `systemadmin` roles about new suspicious logs, improving awareness and prioritization of critical log reviews. (`[um_members.pyR123-R136](diffhunk://#diff-d0b8007d7840bb7a0cff414d79bd4fb9700f9ac839d737e203b4f87799ccca17R123-R136)`)

### Codebase Updates:
* **Imports updated across files**: Added `os` and `fernet` imports where necessary to support log file existence checks and encryption/decryption operations. (`[[1]](diffhunk://#diff-dc1cbd473707e315db118779e4b6227d6b61d5c8837eeb36fd16c45716acc6e5L1-R7)`, `[[2]](diffhunk://#diff-ecda9b2291f096215813c21f006c5ac61b3c622af170797ba5ddc5134c5d3d27L1-R2)`, `[[3]](diffhunk://#diff-d0b8007d7840bb7a0cff414d79bd4fb9700f9ac839d737e203b4f87799ccca17R3-R6)`)