### PR TITLE
Before the rumbling

### DIFF
--- a/DbContext/DbContext.py
+++ b/DbContext/DbContext.py
@@ -78,6 +78,17 @@ class DbContext:
             InServiceDate TEXT NOT NULL DEFAULT (datetime('now'))
         """
         self.create_table("Scooter", scooter_schema)
+        # Create the backup_recovery_list table
+        backup_recovery_list_schema = """
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            backup_name TEXT NOT NULL,
+            system_admin TEXT NOT NULL,
+            recovery_code TEXT NOT NULL,
+            used INTEGER NOT NULL DEFAULT 0,
+            used_at TEXT DEFAULT NULL,
+            created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        """
+        self.create_table("backup_recovery_list", backup_recovery_list_schema)
         self.close()
         
     

--- a/DbContext/backup_utils.py
+++ b/DbContext/backup_utils.py
@@ -27,14 +27,38 @@ def list_backups():
     """List all backup zip files."""
     return [f for f in os.listdir(BACKUP_DIR) if f.endswith('.zip')]
 
-def restore_backup(backup_filename, username=None):
-    """Restore the database from a given backup zip file, preserving backup_recovery_list."""
+def restore_backup(backup_filename, username=None, restore_code=None, system_admin=None):
+    """Restore the database from a given backup zip file, preserving backup_recovery_list.
+    If restore_code and system_admin are provided, mark the code as used before restoring."""
     import sqlite3
     logger = EncryptedLogger()
     backup_path = os.path.join(BACKUP_DIR, backup_filename)
     if not os.path.exists(backup_path):
         logger.log_entry(username or "system", "Restore Backup Failed", f"Backup file not found: {backup_filename}", "Yes")
         raise FileNotFoundError("Backup file not found.")
+    # Step 0: If restore_code and system_admin are provided, mark the code as used before restoring
+    if restore_code and system_admin:
+        try:
+            conn = sqlite3.connect(DB_FILE)
+            cursor = conn.cursor()
+            cursor.execute("SELECT id, backup_name, system_admin, recovery_code, used FROM backup_recovery_list")
+            rows = cursor.fetchall()
+            from DbContext.crypto_utils import decrypt
+            for row in rows:
+                row_id, enc_backup_name, enc_system_admin, enc_code, used = row
+                if (used == 0 and decrypt(enc_backup_name) == backup_filename and
+                    decrypt(enc_system_admin) == system_admin and decrypt(enc_code) == restore_code):
+                    cursor.execute("""
+                        UPDATE backup_recovery_list
+                        SET used = 1, used_at = datetime('now')
+                        WHERE id = ?
+                    """, (row_id,))
+                    conn.commit()
+                    break
+            conn.close()
+        except Exception as e:
+            logger.log_entry(username or "system", "Mark restore code as used Failed", str(e), "Yes")
+            raise
     # Step 1: Export backup_recovery_list
     recovery_rows = []
     try:

--- a/um_members.py
+++ b/um_members.py
@@ -7,7 +7,6 @@ from DbContext.DbContext import DbContext
 from DbContext.crypto_utils import encrypt, decrypt, hash_password, verify_password
 from DbContext.encrypted_logger import EncryptedLogger, fernet
 from Login.verification import Verification
-from scooter import Scooter
 from SuperAdmin import super_admin_menu as SuperMenu
 from systemAdmin import system_admin_menu as SystemMenu
 from serviceEngineer import ServiceEngineer_menu
@@ -193,12 +192,26 @@ def generate_restore_code(length=12):
     return ''.join(random.choices(string.ascii_uppercase + string.digits, k=length))
 
 def add_restore_code(backup_name, system_admin, db_path=DB_PATH):
+    # Fetch all entries and decrypt to check for existing unused code
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    cursor.execute("SELECT backup_name, system_admin, used FROM backup_recovery_list")
+    rows = cursor.fetchall()
+    for enc_backup_name, enc_system_admin, used in rows:
+        try:
+            dec_backup_name = decrypt(enc_backup_name)
+            dec_system_admin = decrypt(enc_system_admin)
+        except Exception:
+            continue
+        if dec_backup_name == backup_name and dec_system_admin == system_admin and used == 0:
+            conn.close()
+            print(f"System Admin '{system_admin}' already has an active recovery code for backup '{backup_name}'.")
+            return None
+    # Generate a new restore code
     code = generate_restore_code()
     enc_backup_name = encrypt(backup_name)
     enc_system_admin = encrypt(system_admin)
     enc_code = encrypt(code)
-    conn = sqlite3.connect(db_path)
-    cursor = conn.cursor()
     cursor.execute("""
         INSERT INTO backup_recovery_list (backup_name, system_admin, recovery_code, used)
         VALUES (?, ?, ?, 0)
@@ -260,6 +273,7 @@ def get_decrypted_backups():
     return backups
 
 def backup_menu(role, username=None):
+    logger = EncryptedLogger()
     while True:
         print("\n=== BACKUP & RESTORE MENU ===")
         print("1. Create Backup")
@@ -267,31 +281,38 @@ def backup_menu(role, username=None):
         print("3. Restore Backup")
         print("4. Delete Backup")
         if role == "superadmin":
-            print(sanitize_output("5. Generate Restore-Code for System Admin"))
-            print(sanitize_output("6. Revoke Restore-Code"))
-            print(sanitize_output("7. Exit Backup Menu"))
+            print("5. Generate Restore-Code for System Admin")
+            print("6. Revoke Restore-Code")
+            print("7. Exit Backup Menu")
             valid_choices = ["1", "2", "3", "4", "5", "6", "7"]
         else:
-            print(sanitize_output("5. Exit Backup Menu"))
+            print("5. Exit Backup Menu")
             valid_choices = ["1", "2", "3", "4", "5"]
         choice = input("Enter your choice: ").strip()
         if choice not in valid_choices:
             print("Invalid choice. Please enter a valid option.")
+            logger.log_entry(username or "system", "Backup Menu", f"Invalid menu choice: {choice}", "No")
             continue
         if choice == "1":
             backup_path = create_backup(username)
-            print(sanitize_output(f"Backup created: {backup_path}"))
+            print(f"Backup created: {backup_path}")
+            logger.log_entry(username or "system", "Backup Menu", f"Created backup: {backup_path}", "No")
+            if role == "systemadmin":
+                print("please contact a Super Admin to add a recovery code for this backup.")
             if role == "superadmin":
                 while True:
                     add_code = input("Do you want to add a recovery code for a System Admin? (yes/no): ").strip().lower()
                     if add_code not in ["yes", "no"]:
                         print("Invalid input. Please enter 'yes' or 'no'.")
+                        logger.log_entry(username or "system", "Backup Menu", f"Invalid input for add recovery code: {add_code}", "No")
                         continue
                     if add_code == "no":
+                        logger.log_entry(username or "system", "Backup Menu", "Chose not to add recovery code after backup.", "No")
                         break
                     admins = get_system_admins()
                     if not admins:
                         print("No active System Admins found.")
+                        logger.log_entry(username or "system", "Backup Menu", "No active System Admins found for recovery code.", "No")
                         break
                     while True:
                         print("System Admins:")
@@ -300,17 +321,22 @@ def backup_menu(role, username=None):
                         sel = input("Select System Admin number: ").strip()
                         if not sel.isdigit() or int(sel) < 1 or int(sel) > len(admins):
                             print("Invalid selection. Please enter a valid number.")
+                            logger.log_entry(username or "system", "Backup Menu", f"Invalid System Admin selection: {sel}", "No")
                             continue
                         sel_idx = int(sel) - 1
                         try:
                             code = add_restore_code(os.path.basename(backup_path), admins[sel_idx])
-                            print(f"Restore code for {admins[sel_idx]} and backup {os.path.basename(backup_path)}: {code}")
+                            if code:
+                                print(f"Restore code for {admins[sel_idx]} and backup {os.path.basename(backup_path)}: {code}")
+                                logger.log_entry(username or "system", "Backup Menu", f"Generated restore code for {admins[sel_idx]} and backup {os.path.basename(backup_path)}", "No")
                             break
                         except Exception as e:
                             print(f"Failed to generate restore code: {e}")
+                            logger.log_entry(username or "system", "Backup Menu", f"Failed to generate restore code: {e}", "Yes")
                     break
         elif choice == "2":
             backups = list_backups()
+            logger.log_entry(username or "system", "Backup Menu", "Listed backups", "No")
             if backups:
                 print("Available backups:")
                 for b in backups:
@@ -321,6 +347,7 @@ def backup_menu(role, username=None):
             backups = list_backups()
             if not backups:
                 print("No backups to restore.")
+                logger.log_entry(username or "system", "Backup Menu", "No backups to restore.", "No")
                 continue
             while True:
                 print("Available backups:")
@@ -329,24 +356,29 @@ def backup_menu(role, username=None):
                 sel = input("Select backup number to restore: ").strip()
                 if not sel.isdigit() or int(sel) < 1 or int(sel) > len(backups):
                     print("Invalid selection. Please enter a valid number.")
+                    logger.log_entry(username or "system", "Backup Menu", f"Invalid restore selection: {sel}", "No")
                     continue
                 sel_idx = int(sel) - 1
                 if role == "systemadmin":
                     code = input("Enter your restore code: ").strip()
                     if not validate_restore_code(backups[sel_idx], username, code):
                         print("Invalid or already used restore code.")
+                        logger.log_entry(username or "system", "Backup Menu", f"Invalid or used restore code for {backups[sel_idx]}", "Yes")
                         continue
                 try:
                     restore_backup(backups[sel_idx], username)
                     print("Restore complete. Please restart the application.")
+                    logger.log_entry(username or "system", "Backup Menu", f"Restored backup: {backups[sel_idx]}", "No")
                     exit()
                 except Exception as e:
                     print(f"Restore failed: {e}")
+                    logger.log_entry(username or "system", "Backup Menu", f"Restore failed: {e}", "Yes")
                 break
         elif choice == "4":
             backups = list_backups()
             if not backups:
                 print("No backups to delete.")
+                logger.log_entry(username or "system", "Backup Menu", "No backups to delete.", "No")
                 continue
             while True:
                 print("Available backups:")
@@ -355,18 +387,22 @@ def backup_menu(role, username=None):
                 sel = input("Select backup number to delete: ").strip()
                 if not sel.isdigit() or int(sel) < 1 or int(sel) > len(backups):
                     print("Invalid selection. Please enter a valid number.")
+                    logger.log_entry(username or "system", "Backup Menu", f"Invalid delete selection: {sel}", "No")
                     continue
                 sel_idx = int(sel) - 1
                 try:
                     delete_backup(backups[sel_idx], username)
                     print(f"Backup deleted: {backups[sel_idx]}")
+                    logger.log_entry(username or "system", "Backup Menu", f"Deleted backup: {backups[sel_idx]}", "No")
                 except Exception as e:
                     print(f"Delete failed: {e}")
+                    logger.log_entry(username or "system", "Backup Menu", f"Delete failed: {e}", "Yes")
                 break
         elif role == "superadmin" and choice == "5":
             backups = list_backups()
             if not backups:
                 print("No backups available.")
+                logger.log_entry(username or "system", "Backup Menu", "No backups available for restore code generation.", "No")
                 continue
             while True:
                 print("Available backups:")
@@ -375,11 +411,13 @@ def backup_menu(role, username=None):
                 sel = input("Select backup number: ").strip()
                 if not sel.isdigit() or int(sel) < 1 or int(sel) > len(backups):
                     print("Invalid selection. Please enter a valid number.")
+                    logger.log_entry(username or "system", "Backup Menu", f"Invalid backup selection for code: {sel}", "No")
                     continue
                 sel_idx = int(sel) - 1
                 admins = get_system_admins()
                 if not admins:
                     print("No active System Admins found.")
+                    logger.log_entry(username or "system", "Backup Menu", "No active System Admins found for code generation.", "No")
                     break
                 while True:
                     print("System Admins:")
@@ -388,19 +426,24 @@ def backup_menu(role, username=None):
                     admin_sel = input("Select System Admin number: ").strip()
                     if not admin_sel.isdigit() or int(admin_sel) < 1 or int(admin_sel) > len(admins):
                         print("Invalid selection. Please enter a valid number.")
+                        logger.log_entry(username or "system", "Backup Menu", f"Invalid System Admin selection for code: {admin_sel}", "No")
                         continue
                     admin_idx = int(admin_sel) - 1
                     try:
                         code = add_restore_code(backups[sel_idx], admins[admin_idx])
-                        print(f"Restore code for {admins[admin_idx]} and backup {backups[sel_idx]}: {code}")
+                        if code:
+                            print(f"Restore code for {admins[admin_idx]} and backup {backups[sel_idx]}: {code}")
+                            logger.log_entry(username or "system", "Backup Menu", f"Generated restore code for {admins[admin_idx]} and backup {backups[sel_idx]}", "No")
                         break
                     except Exception as e:
                         print(f"Failed to generate restore code: {e}")
+                        logger.log_entry(username or "system", "Backup Menu", f"Failed to generate restore code: {e}", "Yes")
                 break
         elif role == "superadmin" and choice == "6":
             backups = list_backups()
             if not backups:
                 print("No backups available.")
+                logger.log_entry(username or "system", "Backup Menu", "No backups available for revoke.", "No")
                 continue
             while True:
                 print("Available backups:")
@@ -409,11 +452,13 @@ def backup_menu(role, username=None):
                 sel = input("Select backup number: ").strip()
                 if not sel.isdigit() or int(sel) < 1 or int(sel) > len(backups):
                     print("Invalid selection. Please enter a valid number.")
+                    logger.log_entry(username or "system", "Backup Menu", f"Invalid backup selection for revoke: {sel}", "No")
                     continue
                 sel_idx = int(sel) - 1
                 admins = get_system_admins()
                 if not admins:
                     print("No active System Admins found.")
+                    logger.log_entry(username or "system", "Backup Menu", "No active System Admins found for revoke.", "No")
                     break
                 while True:
                     print("System Admins:")
@@ -422,21 +467,27 @@ def backup_menu(role, username=None):
                     admin_sel = input("Select System Admin number: ").strip()
                     if not admin_sel.isdigit() or int(admin_sel) < 1 or int(admin_sel) > len(admins):
                         print("Invalid selection. Please enter a valid number.")
+                        logger.log_entry(username or "system", "Backup Menu", f"Invalid System Admin selection for revoke: {admin_sel}", "No")
                         continue
                     admin_idx = int(admin_sel) - 1
                     try:
                         if revoke_restore_code(backups[sel_idx], admins[admin_idx]):
                             print(f"Restore code for {admins[admin_idx]} and backup {backups[sel_idx]} revoked.")
+                            logger.log_entry(username or "system", "Backup Menu", f"Revoked restore code for {admins[admin_idx]} and backup {backups[sel_idx]}", "No")
                         else:
                             print("No active restore code found to revoke.")
+                            logger.log_entry(username or "system", "Backup Menu", f"No active restore code found to revoke for {admins[admin_idx]} and backup {backups[sel_idx]}", "No")
                         break
                     except Exception as e:
                         print(f"Failed to revoke restore code: {e}")
+                        logger.log_entry(username or "system", "Backup Menu", f"Failed to revoke restore code: {e}", "Yes")
                 break
         elif (role == "superadmin" and choice == "7") or (role != "superadmin" and choice == "5"):
+            logger.log_entry(username or "system", "Backup Menu", "Exited backup menu.", "No")
             return
         else:
             print("Invalid choice.")
+            logger.log_entry(username or "system", "Backup Menu", f"Invalid menu choice (else): {choice}", "No")
 
 # === MAIN MENU BEFORE LOGIN ===
 def pre_login_menu():


### PR DESCRIPTION
This pull request introduces significant enhancements to the backup and restore functionality, focusing on security, usability, and role-based access control. Key changes include implementing restore codes for backups, adding methods to manage these codes, and improving the backup menu for better user interaction and logging.

### Security Enhancements:
* Added a whitelist for allowed table names in the `create_table` method to prevent SQL injection attacks. (`DbContext/DbContext.py`, [DbContext/DbContext.pyR20-R23](diffhunk://#diff-d8fec877ef393d17f1855547548efba8a08ec3b91199ce4975630851eafbcbd8R20-R23))
* Integrated restore codes into the backup system to ensure only authorized users can restore backups. Restore codes are encrypted and validated before use. (`DbContext/backup_utils.py`, [DbContext/backup_utils.pyL30-R97](diffhunk://#diff-43ba1f7c91b57258f1bc26da86f2e73a60cab86af569e9cccd4256b2f7adeabeL30-R97))

### Backup and Restore Improvements:
* Added functionality to preserve the `backup_recovery_list` table during database restoration, ensuring recovery codes remain intact after restoring a backup. (`DbContext/backup_utils.py`, [DbContext/backup_utils.pyL30-R97](diffhunk://#diff-43ba1f7c91b57258f1bc26da86f2e73a60cab86af569e9cccd4256b2f7adeabeL30-R97))
* Created methods to generate, revoke, and validate restore codes, allowing Super Admins to manage recovery codes for backups. (`um_members.py`, [um_members.pyR190-R339](diffhunk://#diff-d0b8007d7840bb7a0cff414d79bd4fb9700f9ac839d737e203b4f87799ccca17R190-R339))

### Role-Based Access Control:
* Updated the backup menu to include options for Super Admins to generate and revoke restore codes, while System Admins can only use restore codes to restore backups. (`um_members.py`, [um_members.pyR350-R490](diffhunk://#diff-d0b8007d7840bb7a0cff414d79bd4fb9700f9ac839d737e203b4f87799ccca17R350-R490))
* Modified the `show_main_menu` function to pass the username to the backup menu for logging and role-specific operations. (`um_members.py`, [um_members.pyL178-R179](diffhunk://#diff-d0b8007d7840bb7a0cff414d79bd4fb9700f9ac839d737e203b4f87799ccca17L178-R179))