### PR TITLE
Add validation for maintenance date updates and improve error handling

### DIFF
--- a/scooter/Scooter.py
+++ b/scooter/Scooter.py
@@ -444,14 +444,14 @@ def update_scooter(updater):
             new_maintenance_date = input("New Last Maintenance Date (YYYY-MM-DD): ")
 
             if new_maintenance_date and is_valid_maintenance_date(new_maintenance_date):
-                current_date = decrypt(scooter[12])  # index 12 is LastMaintenanceDate in de DB
-                if is_newer_maintenance_date(new_maintenance_date, current_date):
+                old_date = decrypt(scooter[12])  # index 12 is LastMaintenanceDate in de DB
+                if is_newer_maintenance_date(new_maintenance_date, old_date):
                     db.update_scooter_fields(sn, LastMaintenanceDate=new_maintenance_date)
                     logger.log_entry(f"{updater}", f"Updated scooter {sn}",
                                      f"Updated the last maintenance date to {new_maintenance_date}", "No")
                     return
                 else:
-                    print(f"Invalid Date: {new_maintenance_date} is earlier than current maintenance date ({current_date})")
+                    print(f"Invalid Date: {new_maintenance_date} is earlier than current maintenance date ({old_date})")
             else:
                 print("Invalid Date: Use YYYY-MM-DD format, not older than 1980, not in the future")
 

--- a/scooter/Scooter.py
+++ b/scooter/Scooter.py
@@ -7,7 +7,7 @@ from datetime import datetime
 
 from validation.isValidBatteryCapacity import is_valid_battery_capacity
 from validation.isValidBrand import is_valid_brand
-from validation.isValidMaintenanceDate import is_valid_maintenance_date
+from validation.isValidMaintenanceDate import is_valid_maintenance_date, is_newer_maintenance_date
 from validation.isValidMileage import is_valid_mileage
 from validation.isValidModel import is_valid_model
 from validation.isValidSerialNumber import is_valid_serial_number, validate_serial_number
@@ -442,16 +442,26 @@ def update_scooter(updater):
         tries = 0
         while tries < MAX_TRIES:
             new_maintenance_date = input("New Last Maintenance Date (YYYY-MM-DD): ")
+
             if new_maintenance_date and is_valid_maintenance_date(new_maintenance_date):
-                db.update_scooter_fields(sn, LastMaintenanceDate=new_maintenance_date)
-                logger.log_entry(f"{updater}", f"Updated scooter {sn}", f"Updated the last maintenance date to {new_maintenance_date}", "No")
-                return
+                current_date = decrypt(scooter[12])  # index 12 is LastMaintenanceDate in de DB
+                if is_newer_maintenance_date(new_maintenance_date, current_date):
+                    db.update_scooter_fields(sn, LastMaintenanceDate=new_maintenance_date)
+                    logger.log_entry(f"{updater}", f"Updated scooter {sn}",
+                                     f"Updated the last maintenance date to {new_maintenance_date}", "No")
+                    return
+                else:
+                    print(f"Invalid Date: {new_maintenance_date} is earlier than current maintenance date ({current_date})")
             else:
                 print("Invalid Date: Use YYYY-MM-DD format, not older than 1980, not in the future")
+
             tries += 1
             print(f"You have {MAX_TRIES - tries} attempts left")
+
         print("Too many invalid attempts. Update cancelled.")
-        logger.log_entry(f"{updater}", f"Update cancelled for scooter {sn}", "Too many invalid maintenance date attempts", "Yes")
+        logger.log_entry(f"{updater}", f"Update cancelled for scooter {sn}",
+                         "Too many invalid maintenance date attempts", "Yes")
+
     
     elif field_choice == "12":
         print("Update cancelled.")

--- a/scooter/Scooter_Menu_SerEng.py
+++ b/scooter/Scooter_Menu_SerEng.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from DbContext.crypto_utils import decrypt
 from DbContext.encrypted_logger import EncryptedLogger
 from scooter.Scooter_data import Scooter_data
-from validation.isValidMaintenanceDate import is_valid_maintenance_date
+from validation.isValidMaintenanceDate import is_valid_maintenance_date, is_newer_maintenance_date
 from validation.isValidMileage import is_valid_mileage
 from validation.isValidSerialNumber import is_valid_serial_number
 from validation.isValidStateOfCharge import is_valid_state_of_charge
@@ -157,16 +157,26 @@ def update_scooter_SerEng(updater):
         tries = 0
         while tries < MAX_TRIES:
             new_maintenance_date = input("New Last Maintenance Date (YYYY-MM-DD): ")
+
             if new_maintenance_date and is_valid_maintenance_date(new_maintenance_date):
-                db.update_scooter_fields(sn, LastMaintenanceDate=new_maintenance_date)
-                logger.log_entry(f"{updater}", f"Updated scooter {sn}", f"Updated the last maintenance date to {new_maintenance_date}", "No")
-                return
+                current_date = decrypt(scooter[12])  # index 12 = LastMaintenanceDate
+                if is_newer_maintenance_date(new_maintenance_date, current_date):
+                    db.update_scooter_fields(sn, LastMaintenanceDate=new_maintenance_date)
+                    logger.log_entry(f"{updater}", f"Updated scooter {sn}",
+                                     f"Updated the last maintenance date to {new_maintenance_date}", "No")
+                    return
+                else:
+                    print(f"Invalid Date: {new_maintenance_date} is earlier than current maintenance date ({current_date})")
             else:
                 print("Invalid Date: Use YYYY-MM-DD format, not older than 1980, not in the future")
+
             tries += 1
             print(f"You have {MAX_TRIES - tries} attempts left")
+
         print("Too many invalid attempts. Update cancelled.")
-        logger.log_entry(f"{updater}", f"Update cancelled for scooter {sn}", "Too many invalid maintenance date attempts", "Yes")
+        logger.log_entry(f"{updater}", f"Update cancelled for scooter {sn}",
+                         "Too many invalid maintenance date attempts", "Yes")
+
     
     elif field_choice == "7":
         print("Update cancelled")

--- a/scooter/Scooter_Menu_SerEng.py
+++ b/scooter/Scooter_Menu_SerEng.py
@@ -159,14 +159,14 @@ def update_scooter_SerEng(updater):
             new_maintenance_date = input("New Last Maintenance Date (YYYY-MM-DD): ")
 
             if new_maintenance_date and is_valid_maintenance_date(new_maintenance_date):
-                current_date = decrypt(scooter[12])  # index 12 = LastMaintenanceDate
-                if is_newer_maintenance_date(new_maintenance_date, current_date):
+                old_date = decrypt(scooter[12])  # index 12 = LastMaintenanceDate
+                if is_newer_maintenance_date(new_maintenance_date, old_date):
                     db.update_scooter_fields(sn, LastMaintenanceDate=new_maintenance_date)
                     logger.log_entry(f"{updater}", f"Updated scooter {sn}",
                                      f"Updated the last maintenance date to {new_maintenance_date}", "No")
                     return
                 else:
-                    print(f"Invalid Date: {new_maintenance_date} is earlier than current maintenance date ({current_date})")
+                    print(f"Invalid Date: {new_maintenance_date} is earlier than current maintenance date ({old_date})")
             else:
                 print("Invalid Date: Use YYYY-MM-DD format, not older than 1980, not in the future")
 

--- a/validation/isValidMaintenanceDate.py
+++ b/validation/isValidMaintenanceDate.py
@@ -19,3 +19,11 @@ def is_valid_maintenance_date(maintenance_date_str):
                     except ValueError:
                         pass
     return False
+
+def is_newer_maintenance_date(new_date_str, current_date_str):
+    try:
+        new_date = datetime.strptime(new_date_str, "%Y-%m-%d")
+        current_date = datetime.strptime(current_date_str, "%Y-%m-%d")
+        return new_date >= current_date
+    except ValueError:
+        return False

--- a/validation/isValidMaintenanceDate.py
+++ b/validation/isValidMaintenanceDate.py
@@ -20,10 +20,10 @@ def is_valid_maintenance_date(maintenance_date_str):
                         pass
     return False
 
-def is_newer_maintenance_date(new_date_str, current_date_str):
+def is_newer_maintenance_date(new_date_str, old_date_str):
     try:
         new_date = datetime.strptime(new_date_str, "%Y-%m-%d")
-        current_date = datetime.strptime(current_date_str, "%Y-%m-%d")
-        return new_date >= current_date
+        old_date = datetime.strptime(old_date_str, "%Y-%m-%d")
+        return new_date >= old_date
     except ValueError:
         return False


### PR DESCRIPTION
This pull request adds an additional validation step to the scooter maintenance date update process, ensuring that the new maintenance date is not earlier than the current date. This helps maintain data integrity by preventing accidental backdating of maintenance records. The changes are applied to both the main scooter update flow and the service engineer menu, and a new utility function is introduced for this comparison.

**Maintenance date validation improvements:**

* Added a new function `is_newer_maintenance_date` in `isValidMaintenanceDate.py` to check that a new maintenance date is not earlier than the current maintenance date.
* Updated both `update_scooter` in `Scooter.py` and `update_scooter_SerEng` in `Scooter_Menu_SerEng.py` to use `is_newer_maintenance_date` before allowing maintenance date updates. If the new date is earlier, the update is rejected and a message is shown to the user. [[1]](diffhunk://#diff-92e97ac8a9c6c6b089ceecfe36a582604eae3c933ca5799e52b55fee2e46d59cR445-R464) [[2]](diffhunk://#diff-9a5ca947621348d412954a1b8bdd8f0fbfc9871677c48208f57c9a3f75da960bR160-R179)

**Imports and code organization:**

* Updated imports in `Scooter.py` and `Scooter_Menu_SerEng.py` to include `is_newer_maintenance_date` from `isValidMaintenanceDate.py`. [[1]](diffhunk://#diff-92e97ac8a9c6c6b089ceecfe36a582604eae3c933ca5799e52b55fee2e46d59cL10-R10) [[2]](diffhunk://#diff-9a5ca947621348d412954a1b8bdd8f0fbfc9871677c48208f57c9a3f75da960bL5-R5)