### PR TITLE
Add input validation for city selection in add_traveller function

### DIFF
--- a/traveller/Traveller_menu.py
+++ b/traveller/Traveller_menu.py
@@ -183,6 +183,10 @@ def add_traveller(creator):
     while city is None:
         try:
             city_choice = input(f"Select city (1-{len(db.cities)}): ")
+            if not city_choice.isdigit():
+                raise ValueError
+            if int(city_choice) < 1 or int(city_choice) > len(db.cities):
+                raise IndexError
             city_idx = int(city_choice) - 1
             city = db.cities[city_idx]
             logger.log_entry(f"{creator}", "Input accepted", f"City: {city}", "No")


### PR DESCRIPTION
This pull request improves input validation in the `add_traveller` function to ensure that city selection is both numeric and within the valid range.

Input validation improvements:

* Added checks to ensure the user's city selection is a digit and within the allowed range before proceeding, raising appropriate exceptions otherwise. (`traveller/Traveller_menu.py`, [traveller/Traveller_menu.pyR186-R189](diffhunk://#diff-b2a903c309caa45459b599169d9096bc2092a06dd1820216882399cbd47c8064R186-R189))