### PR TITLE
Improve scooter search functionality to be case-insensitive

### DIFF
--- a/scooter/Scooter_data.py
+++ b/scooter/Scooter_data.py
@@ -338,6 +338,7 @@ class Scooter_data:
             cursor.execute("SELECT * FROM Scooter")
             all_scooters = cursor.fetchall()
             results = []
+            search_lower = str(search_term).lower()
             for s in all_scooters:
                 decrypted_fields = [
                 decrypt(s[0]),  # serialNumber
@@ -349,7 +350,7 @@ class Scooter_data:
                 decrypt(s[10])  # outOfService
                 ]
                 if any(
-                    search_term in (str(field)) for field in decrypted_fields
+                    search_lower in str(field).lower() for field in decrypted_fields
                 ):
                     results.append(s)
             return results


### PR DESCRIPTION
This pull request improves the search functionality in the `search_scooters` method by making the search case-insensitive. Now, searches will match results regardless of letter casing.

Search improvements:

* Modified the search logic in `search_scooters` within `scooter/Scooter_data.py` to convert both the search term and scooter fields to lowercase, ensuring case-insensitive matching. [[1]](diffhunk://#diff-2975a5b4d8c305efd766a464608e563e9926a93e13eaf86605ae68cc5436b73aR341) [[2]](diffhunk://#diff-2975a5b4d8c305efd766a464608e563e9926a93e13eaf86605ae68cc5436b73aL352-R353)