### PR TITLE
removed  numbered error messages

### DIFF
--- a/SuperAdmin/super_admin.py
+++ b/SuperAdmin/super_admin.py
@@ -502,7 +502,7 @@ class SuperAdmin:
         except Exception as e:
             print("Unexpected error occurred while resetting password.")
             logger = EncryptedLogger()
-            logger.log_entry("System", "Unexpected Error in reset_password_function4", f"{e}", "Yes")
+            logger.log_entry("System", "Unexpected Error in reset_password_function", f"{e}", "Yes")
 
 
     def activate_inactive_account(self):

--- a/serviceEngineer/ServiceEngineer.py
+++ b/serviceEngineer/ServiceEngineer.py
@@ -41,7 +41,7 @@ class ServiceEngineer:
         except Exception as e:
             print("Unexpected error occurred while resetting password.")
             logger = EncryptedLogger()
-            logger.log_entry("System", "Unexpected Error in reset_password_function7", f"{e}", "Yes")
+            logger.log_entry("System", "Unexpected Error in reset_password_function", f"{e}", "Yes")
     
     def check_reset_password(self, username):
         try:
@@ -78,7 +78,7 @@ class ServiceEngineer:
         except Exception as e:
             print("Unexpected error occurred while resetting password.")
             logger = EncryptedLogger()
-            logger.log_entry("System", "Unexpected Error in reset_password_function6", f"{e}", "Yes")
+            logger.log_entry("System", "Unexpected Error in reset_password_function", f"{e}", "Yes")
     
     def reset_resetted_password_check(self, username):
         try:
@@ -110,4 +110,4 @@ class ServiceEngineer:
         except Exception as e:
             print("Unexpected error occurred while resetting password.")
             logger = EncryptedLogger()
-            logger.log_entry("System", "Unexpected Error in reset_password_function5", f"{e}", "Yes")
+            logger.log_entry("System", "Unexpected Error in reset_password_function", f"{e}", "Yes")

--- a/systemAdmin/system_admin.py
+++ b/systemAdmin/system_admin.py
@@ -57,7 +57,7 @@ class systemAdmin:
         except Exception as e:
             print("Unexpected error occurred while resetting password.")
             logger = EncryptedLogger()
-            logger.log_entry("System", "Unexpected Error in reset_password_function1", f"{e}", "Yes")
+            logger.log_entry("System", "Unexpected Error in reset_password_function", f"{e}", "Yes")
 
     def reset_resetted_password_check(self, username):
         try:
@@ -85,7 +85,7 @@ class systemAdmin:
         except Exception as e:
             print("Unexpected error occurred while resetting password.")
             logger = EncryptedLogger()
-            logger.log_entry("System", "Unexpected Error in reset_password_function2", f"{e}", "Yes")
+            logger.log_entry("System", "Unexpected Error in reset_password_function", f"{e}", "Yes")
         
 
     def create_service_engineer(self, creator):
@@ -692,7 +692,7 @@ class systemAdmin:
         except Exception as e:
             print("Unexpected error occurred while resetting password.")
             logger = EncryptedLogger()
-            logger.log_entry("System", "Unexpected Error in reset_password_function3", f"{e}", "Yes")
+            logger.log_entry("System", "Unexpected Error in reset_password_function", f"{e}", "Yes")
 
     def reset_password_service_engineer(self, resetter):
         service_engineers = self.view_all_service_engineers()


### PR DESCRIPTION
This pull request standardizes error logging for password reset functions across the `systemAdmin`, `serviceEngineer`, and `SuperAdmin` modules. Previously, each exception log entry used a slightly different function name identifier; now, all have been unified to use `"reset_password_function"` for consistency and easier error tracking.

**Error logging consistency:**

* Updated all exception log entries in password reset-related methods to use `"reset_password_function"` as the function name, replacing various numbered suffixes in `systemAdmin/system_admin.py` (`check_reset_password`, `reset_resetted_password_check`, `reset_password_system`) [[1]](diffhunk://#diff-00e9d5ee6e35547d6dd2d5ccb12809db062944bebc51a06d4dcd3428ea101c22L60-R60) [[2]](diffhunk://#diff-00e9d5ee6e35547d6dd2d5ccb12809db062944bebc51a06d4dcd3428ea101c22L88-R88) [[3]](diffhunk://#diff-00e9d5ee6e35547d6dd2d5ccb12809db062944bebc51a06d4dcd3428ea101c22L695-R695)
* Standardized the function name in exception logging for password reset methods in `serviceEngineer/ServiceEngineer.py` (`reset_password`, `check_reset_password`, `reset_resetted_password_check`) [[1]](diffhunk://#diff-5a5c8881501ac63d0fdd075d95a48746b0fe13b67603e742a548d28a4ea50871L44-R44) [[2]](diffhunk://#diff-5a5c8881501ac63d0fdd075d95a48746b0fe13b67603e742a548d28a4ea50871L81-R81) [[3]](diffhunk://#diff-5a5c8881501ac63d0fdd075d95a48746b0fe13b67603e742a548d28a4ea50871L113-R113)
* Unified the error log entry in `SuperAdmin/super_admin.py` (`reset_password_function`) to use `"reset_password_function"`